### PR TITLE
Add ability to stream workspace generated view and plot data

### DIFF
--- a/src/main/java/com/netlogo/trustmodel/controllers/WorkspaceController.java
+++ b/src/main/java/com/netlogo/trustmodel/controllers/WorkspaceController.java
@@ -383,6 +383,22 @@ public class WorkspaceController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/export-view")
+    public ResponseEntity<?> exportView() {
+        Assert.isTrue(workspace.isReady(), "workspace is not ready");
+
+        return ResponseEntity.ok(workspace.exportView());
+    }
+
+    @GetMapping(value = "/stream-view", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> streamView() {
+        return Flux.generate(sink -> {
+            workspace.go();
+
+            sink.next(workspace.exportView());
+        });
+    }
+
 //    @PostMapping("/command/{source}")
 //    public ResponseEntity<?> commands(@PathVariable("source") String source) {
 //        Assert.isTrue(workspace.isReady(), "workspace is not ready");

--- a/src/main/java/com/netlogo/trustmodel/controllers/WorkspaceController.java
+++ b/src/main/java/com/netlogo/trustmodel/controllers/WorkspaceController.java
@@ -399,6 +399,13 @@ public class WorkspaceController {
         });
     }
 
+    @GetMapping("/plots")
+    public ResponseEntity<?> plots() {
+        Assert.isTrue(workspace.isReady(), "workspace is not ready");
+
+        return ResponseEntity.ok(workspace.plots());
+    }
+
 //    @PostMapping("/command/{source}")
 //    public ResponseEntity<?> commands(@PathVariable("source") String source) {
 //        Assert.isTrue(workspace.isReady(), "workspace is not ready");

--- a/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
+++ b/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
@@ -2,6 +2,8 @@ package com.netlogo.trustmodel.domain;
 
 
 import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
 import lombok.val;
 import org.nlogo.agent.Patch;
 import org.nlogo.agent.Turtle;
@@ -10,6 +12,7 @@ import org.nlogo.api.AgentException;
 import org.nlogo.api.Color;
 import org.nlogo.headless.HeadlessWorkspace;
 import org.nlogo.nvm.RuntimePrimitiveException;
+import org.nlogo.plot.PlotPen;
 import org.springframework.util.Assert;
 import scala.collection.JavaConverters;
 
@@ -21,6 +24,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class HeadlessWorkspaceWrapper {
     private static final String BREED_KEY = "BREED";
@@ -183,6 +188,15 @@ public class HeadlessWorkspaceWrapper {
         return !disposed && workspace.modelOpened();
     }
 
+    public synchronized List<Plot> plots() {
+        Assert.isTrue(isReady(), "workspace is not ready");
+
+        return Stream.of(workspace.plotManager().getPlotNames())
+                .map(pn -> workspace.plotManager().getPlot(pn))
+                .map(Plot::create)
+                .collect(Collectors.toList());
+    }
+
     private String encodeImageToBase64(@NonNull final BufferedImage image) {
         String imageString = null;
 
@@ -207,5 +221,107 @@ public class HeadlessWorkspaceWrapper {
         }
 
         return castingObject;
+    }
+
+    @Value
+    public static class Plot {
+        @NonNull
+        private String name;
+
+        private double xMin;
+
+        private double xMax;
+
+        private double yMin;
+
+        private double yMax;
+
+        private boolean autoPlotOn;
+
+        private boolean legendShown;
+
+        private List<Pen> pens;
+
+        public static Plot create(@NonNull org.nlogo.plot.Plot plot) {
+            return new Plot(
+                    plot.name(),
+                    plot.xMin(),
+                    plot.xMax(),
+                    plot.yMin(),
+                    plot.yMax(),
+                    plot.autoPlotOn(),
+                    plot.legendIsOpen(),
+                    StreamSupport.stream(JavaConverters.asJavaIterable(plot.pens()).spliterator(), true)
+                            .map(Pen::create)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        @Value
+        public static class Pen {
+            @NonNull
+            private String name;
+
+            @NonNull
+            private PenMode mode;
+
+            @NonNull
+            private String color;
+
+            private boolean inLegend;
+
+            @NonNull
+            private List<Point> points;
+
+            public static Pen create(@NonNull PlotPen plotPen) {
+                return new Pen(
+                        plotPen.name(),
+                        PenMode.valueOf(plotPen.mode()),
+                        Utils.convertArgbColorToHexString(plotPen.color()),
+                        plotPen.inLegend(),
+                        StreamSupport.stream(JavaConverters.asJavaIterable(plotPen.points()).spliterator(), true)
+                                .map(plotPoint -> Point.of(plotPoint.x(), plotPoint.y()))
+                                .collect(Collectors.toList())
+                );
+            }
+
+            @Value(staticConstructor = "of")
+            public static class Point {
+                private double x;
+
+                private double y;
+            }
+
+            public enum PenMode {
+                LINE,
+                BAR,
+                POINT;
+
+                public static PenMode valueOf(final int mode) {
+                    if (mode == 0) {
+                        return LINE;
+                    } else if (mode == 1) {
+                        return BAR;
+                    } else if (mode == 2) {
+                        return POINT;
+                    } else {
+                        throw new IllegalArgumentException("unexpected mode: " + mode);
+                    }
+                }
+            }
+        }
+    }
+
+    @UtilityClass
+    private static class Utils {
+        public String convertNetLogoColorToHexString(final double netLogoColor) {
+            val color = Color.getColor(netLogoColor);
+
+            return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+        }
+
+        public String convertArgbColorToHexString(final int argbColor) {
+            return convertNetLogoColorToHexString(Color.argbToColor(argbColor));
+        }
     }
 }

--- a/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
+++ b/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
@@ -198,12 +198,13 @@ public class HeadlessWorkspaceWrapper {
     }
 
     private String encodeImageToBase64(@NonNull final BufferedImage image) {
-        String imageString = null;
+        // Default to a 1x1 transparent GIF
+        String imageString = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
 
         try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             ImageIO.write(image, "png", outputStream);
 
-            imageString = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+            imageString = "data:image/png;base64," + Base64.getEncoder().encodeToString(outputStream.toByteArray());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
+++ b/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
@@ -13,6 +13,10 @@ import org.nlogo.nvm.RuntimePrimitiveException;
 import org.springframework.util.Assert;
 import scala.collection.JavaConverters;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -43,6 +47,12 @@ public class HeadlessWorkspaceWrapper {
     public synchronized void go() {
         Assert.isTrue(isReady(), "workspace is not ready");
         workspace.command("go");
+    }
+
+    public synchronized String exportView() {
+        Assert.isTrue(isReady(), "workspace is not ready");
+
+        return encodeImageToBase64(workspace.exportView());
     }
 
     public synchronized void wave() {
@@ -171,6 +181,20 @@ public class HeadlessWorkspaceWrapper {
 
     public boolean isReady() {
         return !disposed && workspace.modelOpened();
+    }
+
+    private String encodeImageToBase64(@NonNull final BufferedImage image) {
+        String imageString = null;
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", outputStream);
+
+            imageString = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return imageString;
     }
 
     // This method is to Casting the Division by Zero exception from Workspace

--- a/src/main/resources/templates/demo.html
+++ b/src/main/resources/templates/demo.html
@@ -9,32 +9,24 @@
             <h1>Demo!</h1>
             <button id="start-stream">Start Stream</button>
             <button id="end-stream">End Stream</button>
-            <div id="demo-variables-container">
 
-            </div>
-
+            <img id="demo-streaming-view"/>
         </th:block>
 
         <script>
             var streamModelSource;
-            var demoVariablesContainer = document.getElementById("demo-variables-container");
+            var demoDrawingImage = document.getElementById("demo-streaming-view");
 
             document.getElementById("start-stream").addEventListener("click", function () {
-                streamModelSource = new EventSource("http://localhost:8080/workspace/stream-model");
-                // return new Promise((resolve, reject) => {
-                //     resolve(afun(streamModelSource.onmessage));
-                // });
-                streamModelSource.onmessage = afun;
+                streamModelSource = new EventSource("http://localhost:8080/workspace/stream-view");
+                streamModelSource.onmessage = function (event) {
+                    demoDrawingImage.src = "data:image/png;base64, " + event.data;
+                };
             });
 
             document.getElementById("end-stream").addEventListener("click", function () {
                 streamModelSource.close();
             });
-            afun = function (event) {
-                setTimeout(function () {
-                    demoVariablesContainer.innerHTML = "id: " + event.id + ", data: " +event.data;
-                }, 1000);
-            }
         </script>
     </body>
 </html>

--- a/src/main/resources/templates/demo.html
+++ b/src/main/resources/templates/demo.html
@@ -20,7 +20,7 @@
             document.getElementById("start-stream").addEventListener("click", function () {
                 streamModelSource = new EventSource("http://localhost:8080/workspace/stream-view");
                 streamModelSource.onmessage = function (event) {
-                    demoDrawingImage.src = "data:image/png;base64, " + event.data;
+                    demoDrawingImage.src = event.data;
                 };
             });
 


### PR DESCRIPTION
The new endpoint exports the generated view directly from the workspace -- without first writing to the filesystem -- and encodes the image as a PNG/Base64.

The demo HTML has been updated as well to show how smoothly the image can be streamed to a browser.