### PR TITLE
Refactor events and reporter registration

### DIFF
--- a/src/main/java/com/netlogo/trustmodel/services/WorkspaceGoEventListener.java
+++ b/src/main/java/com/netlogo/trustmodel/services/WorkspaceGoEventListener.java
@@ -3,6 +3,7 @@ package com.netlogo.trustmodel.services;
 import com.netlogo.trustmodel.domain.HeadlessWorkspaceWrapper.World;
 import com.netlogo.trustmodel.services.WorkspaceService.WorkspaceGoEvent;
 import lombok.NonNull;
+import lombok.val;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.FluxSink;
@@ -14,14 +15,22 @@ import java.util.List;
 public class WorkspaceGoEventListener implements ApplicationListener<WorkspaceGoEvent> {
     private List<FluxSink<World>> fluxSinks = new ArrayList<>();
 
+    private World lastWorld = World.EMPTY;
+
     public void addFluxSink(@NonNull final FluxSink<World> fluxSink) {
         fluxSinks.add(fluxSink);
+
+        fluxSink.next(lastWorld);
     }
 
     @Override
     public void onApplicationEvent(WorkspaceGoEvent event) {
-        fluxSinks.forEach(fs -> fs.next(event.getWorld()));
-
         fluxSinks.removeIf(FluxSink::isCancelled);
+
+        val currentWorld = event.getWorld();
+
+        fluxSinks.forEach(fs -> fs.next(currentWorld));
+
+        lastWorld = currentWorld;
     }
 }


### PR DESCRIPTION
WorkspaceGoEventListener now caches the previous event’s world so that it can push an initial world state to newly added fluxSinks.

Report registration, clearing of the registered reports, setup, and workspace init all publish a go event so that the listener can update each of the connected fluxSinks more effectively.