### PR TITLE
Add explicit getters for x/y min/max fields

### DIFF
--- a/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
+++ b/src/main/java/com/netlogo/trustmodel/domain/HeadlessWorkspaceWrapper.java
@@ -1,6 +1,5 @@
 package com.netlogo.trustmodel.domain;
 
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.NonNull;
 import lombok.Value;
@@ -197,16 +196,12 @@ public class HeadlessWorkspaceWrapper {
         @NonNull
         private String name;
 
-        @JsonProperty("xMin")
         private double xMin;
 
-        @JsonProperty("xMax")
         private double xMax;
 
-        @JsonProperty("yMin")
         private double yMin;
 
-        @JsonProperty("yMax")
         private double yMax;
 
         private boolean autoPlotOn;
@@ -228,6 +223,30 @@ public class HeadlessWorkspaceWrapper {
                             .map(Pen::create)
                             .collect(Collectors.toList())
             );
+        }
+
+        // Required to fix conflict between Jackson and Lombok naming conventions
+        @JsonProperty("xMin")
+        public double getXMin() {
+            return xMin;
+        }
+
+        // Required to fix conflict between Jackson and Lombok naming conventions
+        @JsonProperty("xMax")
+        public double getXMax() {
+            return xMax;
+        }
+
+        // Required to fix conflict between Jackson and Lombok naming conventions
+        @JsonProperty("yMin")
+        public double getYMin() {
+            return yMin;
+        }
+
+        // Required to fix conflict between Jackson and Lombok naming conventions
+        @JsonProperty("yMax")
+        public double getYMax() {
+            return yMax;
         }
 
         @Value


### PR DESCRIPTION
Jackson and Lombok have a hard time dealing with x/y min/max variable names when inferring deserialisation field names. By explicitly defining the getters for these fields and moving @JsonProperty to the getter we avoid a doubling up of field values in the resulting JSON.